### PR TITLE
Add Quick Start and Usage Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ npm install
 npm run dev
 ```
 
+4. The app will be ready at:
+```
+http://localhost:5173/chickenbook/
+```
+
 ### See the app deployed in GitHub pages
 ```
 https://jg-chickenbook.github.io/chickenbook/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,31 @@ Our goal is to create an app where members of Junior Guru[^1] can log in and cre
 
 ## 🏁 Quick Start
 
-> Will be added after migration to Vite if we agree on it
+### Run the app locally
 
-## 🤝 Collaboration
+1. Clone the repository
+```
+git clone https://github.com/jg-chickenbook/chickenbook.git
+```
+2. Open the project and install dependencies
+```
+npm install
+```
+3. Run the app by using this command
+```
+npm run dev
+```
+
+### See the app deployed in GitHub pages
+```
+https://jg-chickenbook.github.io/chickenbook/
+```
+
+</br>
+</br>
+<details close><summary><b>🤝 Collaboration Guide</b></summary>
+</br>
+</br>
 
 `ISSUE` ➡️ `BRANCH` ➡️ `COMMITS` & `PUSHES` ➡️ `PULL REQUEST` ➡️ `CODE REVIEW` ➡️ `MERGE into DEV`
 
@@ -82,3 +104,5 @@ Each pull requests should contain at least basic information about the changes. 
 - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [colorize](https://marketplace.visualstudio.com/items?itemName=kamikillerto.vscode-colorize)
+
+</details>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Each branch should be created from an issue and issues should ideally mirror tas
 
 The name of the branch should has the following format:
 
-`<branch-category>/<name-initials>-<issue-number>-<issue-name>`
+`<branch-category>/<issue-number>-<issue-name>`
 ```
 EXAMPLE: feature/30-profile-screen
 feature = branch category

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ npm run dev
 https://jg-chickenbook.github.io/chickenbook/
 ```
 
+## 🧑‍💻 Usage
+- You can currently see all the public profiles. 
+  - The profiles consist of "dummy data" for now.
+- A detailed profile can be displayed by clicking on the profile card.
+- It's also possible to register and log into the app.
+
 </br>
 </br>
 <details close><summary><b>🤝 Collaboration Guide</b></summary>


### PR DESCRIPTION
Just README updates so @Aberran and @trnecka  or someone else knows how to run the project locally.

What's new?
- Quick Start and Usage sections in README.md
__________

What's been modified?
- A few inaccuracies in README.md
- Collaboration guide is hidden by default
__________

Someone, please give me approval so I can push the changes into the dev branch.